### PR TITLE
fix: implement sticky footer to resolve mobile layout floating issue

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+  <p>© 2025 XAlchemyst Technologies Pvt. Ltd. All rights reserved.</p>
+</footer>

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,1 +1,29 @@
 <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<style>
+  /* 1. Force the page container to be at least as tall as the phone screen */
+  html, body {
+    height: 100%;
+    margin: 0;
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  /* 2. Target the main content. This tells it to 'grow' and take up 
+     all available empty space, which pushes the footer to the bottom. */
+  main, #content, .container, .wrapper {
+    flex: 1 0 auto;
+  }
+
+  /* 3. Style the footer so it stays anchored */
+  footer, .site-footer {
+    flex-shrink: 0;
+    padding: 2rem 1rem;
+    background: #000;
+    text-align: center;
+    width: 100%;
+  }
+</style>


### PR DESCRIPTION
This PR addresses a layout regression on mobile devices where the footer would "float" in the middle of the viewport on pages with short content. This was primarily caused by the main content container not having a minimum height, allowing the footer to pull upward on smaller screens.

Changes
Sticky Footer Logic: Injected a Flexbox-based layout fix into _includes/head-custom.html.

Viewport Height: Set the body to min-height: 100vh to ensure the page always fills the screen.

Flexbox Positioning: Applied flex: 1 0 auto to the main content area to push the footer firmly to the bottom of the viewport.

Footer Component: Added a local _includes/footer.html to standardize the footer structure across the site.

Verification Results
<img width="1396" height="1634" alt="image" src="https://github.com/user-attachments/assets/4240baf1-2e67-420c-84a2-a0863a357a57" />

I verified this fix locally by creating a responsive mockup that simulates the Alchemyst AI page structure.

Before: On an iPhone SE/12 Pro viewport, the footer appeared immediately after the content, leaving a large black void at the bottom.

After: The footer remains anchored to the bottom edge of the screen regardless of content length.